### PR TITLE
Fix: get random array index

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -15,7 +15,7 @@ const count = words.length;
 const server = serve({ port: 8000 });
 
 for await (const req of server) {
-  const index = Math.floor(Math.random() * count);
+  const index = Math.ceil(Math.random() * count - 1);
   const body = createHtml(words[index]);
   req.respond({ body });
 }


### PR DESCRIPTION
There is a potentially undefined value that `Math.random()` return `(0, 1]` which makes `index` equal to `arr.length` when using 
```javascript
const index = Math.floor(Math.random() * count)
```